### PR TITLE
memberListActivities Fix console icons (Xbox & Playstation)

### DIFF
--- a/memberListActivities/index.tsx
+++ b/memberListActivities/index.tsx
@@ -60,6 +60,7 @@ interface Activity {
         small_text?: string;
         small_image?: string;
     };
+    platform?: string;
 }
 
 const cl = classNameFactory("vc-mla-");
@@ -78,6 +79,7 @@ interface Application {
     publishers: Developer[];
     developers: Developer[];
     flags: number;
+    platform?: string;
 }
 
 interface Developer {
@@ -126,10 +128,10 @@ export default definePlugin({
             icons.push(<TwitchIcon />);
         }
 
-        const applications = activities.filter(activity => activity.application_id);
+        const applications = activities.filter(activity => activity.application_id || activity.platform);
         applications.forEach(activity => {
-            const { assets, application_id } = activity;
-            if (!application_id) {
+            const { assets, application_id, platform } = activity;
+            if (!application_id && !platform) {
                 return;
             }
             if (assets) {
@@ -170,9 +172,13 @@ export default definePlugin({
                 }
 
                 if (application) {
-                    const xbox_application_id = "438122941302046720";
-                    const src = application.id === xbox_application_id ? "https://discord.com/assets/9a15d086141be29d9fcd.png" : `https://cdn.discordapp.com/app-icons/${application.id}/${application.icon}.png`;
+                    const src = application?.platform === 'xbox' && application.icon === null ? "https://discord.com/assets/9a15d086141be29d9fcd.png" : `https://cdn.discordapp.com/app-icons/${application.id}/${application.icon}.png`;
                     icons.push(<img src={src} alt={application.name} />);
+                } else {
+                    if (platform === 'xbox') {
+                        const src = 'https://discord.com/assets/9a15d086141be29d9fcd.png';
+                        icons.push(<img src={src} alt='Xbox' />);
+                    }
                 }
             }
         });

--- a/memberListActivities/index.tsx
+++ b/memberListActivities/index.tsx
@@ -79,7 +79,6 @@ interface Application {
     publishers: Developer[];
     developers: Developer[];
     flags: number;
-    platform?: string;
 }
 
 interface Developer {
@@ -172,7 +171,7 @@ export default definePlugin({
                 }
 
                 if (application) {
-                    const src = application?.platform === 'xbox' && application.icon === null ? "https://discord.com/assets/9a15d086141be29d9fcd.png" : `https://cdn.discordapp.com/app-icons/${application.id}/${application.icon}.png`;
+                    const src = platform === 'xbox' && application.icon === null ? "https://discord.com/assets/9a15d086141be29d9fcd.png" : `https://cdn.discordapp.com/app-icons/${application.id}/${application.icon}.png`;
                     icons.push(<img src={src} alt={application.name} />);
                 } else {
                     if (platform === 'xbox') {


### PR DESCRIPTION
- adds a platform variable in activity/application (console only)
- switch the xbox application id check with the xbox platform check instead 
- add an additional check for xbox icons being null (future proof in case xbox adds it) 
- add an additional check if application is false for xbox (this block will be used for the noicon update as well)

Every Playtation user has given back assets with small_image so just adding the platform indicator fixes playstation users. If we want to add an additional icon for PS users (PS Icon) to be uniform with the current Xbox style, we can use the platform indicator (platform = ps4 || platform = ps5) to check for playstation users.