### PR TITLE
MemberListActivities: Fix Duplicate Icons

### DIFF
--- a/memberListActivities/index.tsx
+++ b/memberListActivities/index.tsx
@@ -184,9 +184,15 @@ export default definePlugin({
         });
 
         if (icons.length) {
+            const compareJSXElementsSource = (a: JSX.Element, b: JSX.Element) => {
+                return JSON.stringify(a.props.src) === JSON.stringify(b.props.src);
+            }
+            const uniqueIcons = icons.filter((element, index, array) => {
+                return array.findIndex(el => compareJSXElementsSource(el, element)) === index;
+            });
             return <ErrorBoundary noop>
                 <div className={cl("row")}>
-                    {icons.map((icon, i) => (
+                    {uniqueIcons.map((icon, i) => (
                         <div key={i} className={cl("icon")} style={{ width: `${settings.store.iconSize}px`, height: `${settings.store.iconSize}px` }}>
                             {icon}
                         </div>


### PR DESCRIPTION
Filter and compare props.src of each JSX element in icons

Fixes https://github.com/D3SOX/vencord-userplugins/issues/5 , This doesn't take into account the Custom twitch icon + premid twitch icon, though that is technically a different issue altogether.

Third Party applications can spam activities causing multiple duplicate or semi-duplicate icons. 
From what I've seen from the "Crunchyroll" activities, it can either be duplicate activities or "different" (different episode) activities but the same icon. 
A typical de-dupe using props:props comparison doesn't take into account of these "different" activities with the same icon so we use the src prop instead comparing the image url.
