### PR TITLE
MemberListActivities: Fix null icon

### DIFF
--- a/memberListActivities/index.tsx
+++ b/memberListActivities/index.tsx
@@ -173,8 +173,12 @@ export default definePlugin({
                 }
 
                 if (application) {
-                    const src = platform === "xbox" && application.icon === null ? xboxUrl : `https://cdn.discordapp.com/app-icons/${application.id}/${application.icon}.png`;
-                    icons.push(<img src={src} alt={application.name} />);
+                    if (application.icon) {
+                        const src = `https://cdn.discordapp.com/app-icons/${application.id}/${application.icon}.png`;
+                        icons.push(<img src={src} alt={application.name} />);
+                    } else if (platform === "xbox") {
+                        icons.push(<img src={xboxUrl} alt="Xbox" />);
+                    }
                 }
             } else {
                 if (platform === "xbox") {


### PR DESCRIPTION
refactor app logic to check for application.icon first, then check for the platform 
Xbox currently has no app icon, this keeps current functionality in case they decided to add some in the future.

Reversing the application.icon check allows us to make sure there's no null icon before trying to use it.
The Xbox icon should match in both places used.

Fixes https://github.com/D3SOX/vencord-userplugins/issues/2